### PR TITLE
Fix #138, reviewed database structure

### DIFF
--- a/suricate/api/views.py
+++ b/suricate/api/views.py
@@ -118,8 +118,10 @@ def get_commands_from_datetimex_to_datetimey(dtx, dty):
 @main.route('/attr/<system>/<component>/<name>/<int:N>', methods=['GET'])
 def get_last_attribute_values(system, component, name, N):
     """Returns the last N commands"""
-    key = f'{system}/{component}/{name}'
-    attrs = Attribute.query.filter(Attribute.name == key)
+    attrs = Attribute.query.filter(
+        Attribute.system == f'{system}/{component}',
+        Attribute.name == f'{name}'
+    )
     attrs = attrs.order_by(desc(Attribute.timestamp)).limit(N).all()
     if not attrs:
         response = {
@@ -139,11 +141,11 @@ def get_last_default_attribute_values(system, component, name):
 @main.route('/attr/<system>/<component>/<name>/from/<dtx>', methods=['GET'])
 def get_attribute_from_datetimex(system, component, name, dtx):
     """Return all attributes values from datetime dtx until now"""
-    key = f'{system}/{component}/{name}'
     try:
         dtx = datetime.strptime(dtx, dt_format)
         attrs = Attribute.query.filter(
-            Attribute.name == key,
+            Attribute.system == f'{system}/{component}',
+            Attribute.name == f'{name}',
             Attribute.timestamp >= dtx,
         ).order_by(Attribute.timestamp.desc()).all()
     except ValueError:
@@ -173,12 +175,12 @@ def get_attribute_from_datetimex_to_datetimey(
     dty
 ):
     """Returns all attribute values from datetime dtx to dty"""
-    key = f'{system}/{component}/{name}'
     try:
         dtx = datetime.strptime(dtx, dt_format)
         dty = datetime.strptime(dty, dt_format)
         attrs = Attribute.query.filter(
-            Attribute.name == key,
+            Attribute.system == f'{system}/{component}',
+            Attribute.name == f'{name}',
             Attribute.timestamp >= dtx,
             Attribute.timestamp <= dty,
         ).order_by(Attribute.timestamp.desc()).all()

--- a/suricate/dbfiller/__init__.py
+++ b/suricate/dbfiller/__init__.py
@@ -52,9 +52,11 @@ class DBFiller:
                     continue  # Do not store error messages
 
                 timestamp = datetime.strptime(data['timestamp'], dt_format)
+                system = key[:key.rfind('/')]
+                name = key[key.rfind('/') + 1:]
                 attr = Attribute(
-                    id=f'{key} @ {data["timestamp"]}',
-                    name=key,
+                    system=system,
+                    name=name,
                     units=data['units'],
                     timestamp=timestamp,
                     timer=data['timer'],

--- a/suricate/models.py
+++ b/suricate/models.py
@@ -48,9 +48,9 @@ class Command(db.Model):
 class Attribute(db.Model):
     __tablename__ = 'attributes'
 
-    id = db.Column(db.String(128), primary_key=True)
-    name = db.Column(db.String(64), nullable=False)
-    timestamp = db.Column(db.DateTime, nullable=False)
+    system = db.Column(db.String(128), primary_key=True)
+    name = db.Column(db.String(128), primary_key=True)
+    timestamp = db.Column(db.DateTime, primary_key=True)
     timer = db.Column(db.Float, nullable=False)
     value = db.Column(db.String(256))
     description = db.Column(db.String(128))
@@ -58,7 +58,7 @@ class Attribute(db.Model):
     error = db.Column(db.String(128), default='')
 
     def __repr__(self):
-        return f'<Attribute {self.id}>'
+        return f'<Attribute {self.system}/{self.name} @ {self.timestamp}>'
 
     def get_timestamp_str(self, _dt_format=dt_format):
         return self.timestamp.strftime(_dt_format)

--- a/tests/api/test_server_api.py
+++ b/tests/api/test_server_api.py
@@ -327,7 +327,8 @@ def test_get_last_attributes(client, dbfiller, redis_client):
     raw_response = client.get('/attr/%s/%d' % (key1, N))
     response = raw_response.get_json()
     assert len(response) == N
-    assert response[0]['name'] == key1
+    assert response[0]['system'] == 'SYSTEM/Component'
+    assert response[0]['name'] == 'name1'
     assert response[0]['value'] == ATTRIBUTE['value']
     assert response[0]['timestamp'] > response[N-1]['timestamp']
     raw_response = client.get('/attr/%s/%d' % (key2, N-1))

--- a/tests/dbfiller/test_dbfiller.py
+++ b/tests/dbfiller/test_dbfiller.py
@@ -85,29 +85,42 @@ def test_no_timestamp_in_data(client, dbfiller, redis_client):
 
 def test_store_attribute(client, dbfiller, redis_client):
     """Store the attribute to db"""
-    key = 'SYSTEM/Component/name'
+    system = 'SYSTEM/Component'
+    name = 'name'
+    key = f'{system}/{name}'
     attribute['timestamp'] = datetime.utcnow().strftime(dt_format)
     redis_client.hset(key, mapping=attribute)
     redis_client.set('__dbfiller_stop', 'yes')
     dbfiller.dbfiller()
-    result = Attribute.query.filter(Attribute.name == key).first()
+    result = Attribute.query.filter(
+        Attribute.system == system,
+        Attribute.name == name
+    ).first()
     assert result.timer == attribute['timer']
 
 
 def test_store_attribute_by_process(client, dbfiller, redis_client):
     """Start the process and verify it stores only one attribute"""
-    key = 'SYSTEM/Component/name'
+    system = 'SYSTEM/Component'
+    name = 'name'
+    key = f'{system}/{name}'
     attribute['timestamp'] = datetime.utcnow().strftime(dt_format)
     redis_client.hset(key, mapping=attribute)
     dbfiller.start()
     # Wait a little bit, to be sure the process has the
     # chance to store more than one attribute
     time.sleep(config['SCHEDULER']['dbfiller_cycle']*5)
-    query = Attribute.query.filter(Attribute.name == key).all()
+    query = Attribute.query.filter(
+        Attribute.system == system,
+        Attribute.name == name
+    ).all()
     # All items have different timestamp. It means in this case
     # there should be only one item stored on db
     assert len(query) == 1
-    dbattr = Attribute.query.filter(Attribute.name == key).first()
+    dbattr = Attribute.query.filter(
+        Attribute.system == system,
+        Attribute.name == name
+    ).first()
     assert dbattr.timer == attribute['timer']
 
 


### PR DESCRIPTION
This modification allows more granularity in the database. The attributes' `ID` column has been split into `system` and `name`, which represent respectively the system (e.g.: `ANTENNA/Boss`) and the name (e.g.: `rawAzimuth`) of the attribute.
The old `ID` column also stored the timestamp, but this is stored as well in the dedicated column, making it redundant.
The database could still be improved but we will open different issues for each improvement we plan to make.